### PR TITLE
Adding --auto-save-interval=1 config

### DIFF
--- a/src/Aria4net/Server/Aria2cProcessStarter.cs
+++ b/src/Aria4net/Server/Aria2cProcessStarter.cs
@@ -31,7 +31,7 @@ namespace Aria4net.Server
         {
             try
             {
-                Logger.Info("Processo executou com código {0}.", sender.ExitCode);
+                Logger.Info("Processo executou com codigo {0}.", sender.ExitCode);
                 if (0 <= sender.ExitCode)
                     throw new Aria2cException(sender.ExitCode, sender.StandardError.ReadToEnd());
             }
@@ -52,7 +52,7 @@ namespace Aria4net.Server
 
             return
                 string.Format(
-                    "--enable-rpc --dir=\"{0}\" --quiet --listen-port={1} --rpc-listen-port={2} --follow-torrent=false --file-allocation=trunc -c --show-console-readout=false --stop-with-process={3} --max-concurrent-downloads={4} --max-overall-download-limit={5} --max-overall-upload-limit={6}",
+                    "--enable-rpc --dir=\"{0}\" --quiet --listen-port={1} --rpc-listen-port={2} --follow-torrent=false --file-allocation=trunc -c --show-console-readout=false --stop-with-process={3} --max-concurrent-downloads={4} --max-overall-download-limit={5} --max-overall-upload-limit={6} --auto-save-interval=1",
                     DownloadedFilesDirPath().Trim(),
                     _config.Port,
                     _config.RpcPort,


### PR DESCRIPTION
http://aria2.sourceforge.net/manual/pt/html/aria2c.html?highlight=#cmdoption--auto-save-interval

A geração/atualização do .aria2 por default é de 60.

O problema disso é que se o download for iniciado e a aplicação for terminada antes da geração do aria2 (60 segundos por padrão) ocorre erro ao continuar o download posteriormente.

Alterando a configuração para gerar a cada 1 segundo, impede essa situação, visto que a geração do arquivo é praticamente instantanea.

[]'s
